### PR TITLE
Serial command refactorization

### DIFF
--- a/ArduinoCode/SamplerSerialEverythingV1.9OptoRTC/ConfigurationMethods.ino
+++ b/ArduinoCode/SamplerSerialEverythingV1.9OptoRTC/ConfigurationMethods.ino
@@ -1,0 +1,172 @@
+/**
+ * This file contains methods for manipulating the configuration struct and
+ * OPEnSampler state. The struct is declared in SamplerSerialEverythingv1.90ptoRTC.ino
+ */
+
+bool puppetValveState(unsigned int valveNumber, bool valveState)
+{
+  if(valveNumber < 0 || valveNumber > NUM_VALVES)
+  {
+    Serial.print(F("ERROR: Specified valve does not exist: "));
+    Serial.println(valveNumber);
+    return false;
+  }
+
+  configuration.VNum = valveNumber;
+
+  Serial.print(F("Toggling valve: "));
+  Serial.println(valveNumber);
+  Serial.print(F("Valve is now "));
+
+  // Valve 0 is the flush valve, and is handled uniquely from the others
+  if(valveNumber == 0)
+  {
+    if(valveState) // then turn flush on or off depending on valveState
+    {
+      flushON();   // Flush bit on, Preserves valve bits
+      Serial.println(F("open."));
+    }
+    else
+    {
+      flushOFF();
+      Serial.println(F("closed."));
+    }
+    return true;
+  }
+
+  if(valveState)
+  {
+    Serial.println(F("open."));
+    // Configure TPIC buffers according to current valve, strobe out to SPI
+    setValveBits(); // Assumes you only want one valve on at a time, auto closes other valves
+  }
+  else
+  {
+    Serial.println(F("closed."));
+    clearValveBits(); // CLEAR valve bits, preserve flush bit
+  }
+  return true;
+}
+
+void setAlarmPeriod()
+{
+  DateTime now = RTC.now(); // Check the current time
+
+  // Calculate new time
+  configuration.SAMin = (now.minute()+configuration.SAPer)%60;  // wrap-around using modulo every 60 sec
+  configuration.SAHr  = (now.hour()+((now.minute()+configuration.SAPer)/60))%24; // quotient of now.min+periodMin added to now.hr, wraparound every 24hrs
+
+  Serial.print(F("Resetting Alarm 1 for: ")); Serial.print(configuration.SAHr); Serial.print(F(":"));Serial.println(configuration.SAMin);
+
+   // Set alarm1
+   RTC.setAlarm(ALM1_MATCH_HOURS, configuration.SAMin, configuration.SAHr, 0);
+}
+
+/**
+ * Set a daily alarm to sample at the specified hour and minute of the day.
+ *
+ * Automatically switches to daily sampling mode and resets the sample alarm.
+ */
+void setDailyAlarm(unsigned int hour, unsigned int minute)
+{
+  configuration.Is_Daily = true;
+
+  configuration.SAHr = hour;
+  configuration.SAMin = minute;
+
+  RTC.setAlarm(ALM1_MATCH_HOURS, configuration.SAMin, configuration.SAHr, 0);
+}
+
+/**
+ * Set the duration of a flush in milliseconds.
+ *
+ * Returns false and fails if the value is not positive.
+ */
+bool setFlushDuration(unsigned int milliseconds)
+{
+  if (milliseconds == 0)
+  {
+    Serial.println(F("ERROR: Flush duration must be a positive value."));
+    return false;
+  }
+
+  configuration.FDMs = milliseconds;
+  return true;
+}
+
+/**
+ * Set the valve number of the next valve/bag to sample into.
+ *
+ * Returns false and fails if the next valve is < 1.
+ */
+bool setNextValve(unsigned int valveNumber)
+{
+  if (valveNumber == 0)
+  {
+    Serial.println(F("ERROR: Next valve number must be a positive value."));
+    return false;
+  }
+
+  // The value is decremented before storing because it will be incremented
+  // automatically in the main loop.
+  configuration.VNum = valveNumber - 1;
+  return true;
+}
+
+/**
+ * Set a periodic alarm which samples repeatedly after the specified interval.
+ *
+ * The alarm period must be longer than the flush and sample durations or the
+ * operation will fail. If passed a valid period length, periodic alarm mode
+ * will be enabled automatically and the current sample alarm will be reset.
+ *
+ * Returns true if the periodic alarm is updated successfully.
+ */
+bool setPeriodicAlarm(unsigned int minutes)
+{
+  if((minutes * 60 * 1000) <= (configuration.FDMs+configuration.SDMs))
+  {
+    Serial.print(F("ERROR: Sample period of "));
+    Serial.print(minutes);
+    Serial.println(F(" must be at least flush and sample durations combined."));
+    return false;
+  }
+
+  configuration.SAPer = minutes;
+  configuration.Is_Daily = false; // Switch to periodic mode
+  setAlarmPeriod(); // Reset alarm with new period length
+  return true;
+}
+
+/**
+ * Set the duration of a sample in milliseconds.
+ *
+ * Returns false and fails if the value is not positive.
+ */
+bool setSampleDuration(unsigned int milliseconds)
+{
+  if (milliseconds == 0)
+  {
+    Serial.println(F("ERROR: Sample duration must be a positive value."));
+    return false;
+  }
+
+  configuration.SDMs = milliseconds;
+  return true;
+}
+
+/**
+ * Set the real time clock and reset the sample alarm.
+ *
+ * Sets the real time clock to the specified year, month, day, hour, and minute.
+ * Also resets daily or periodic alarms to begin from the updated time.
+ */
+void setClock(unsigned int year, unsigned int month, unsigned int day, unsigned int hour, unsigned int minute)
+{
+  RTC.adjust(DateTime(year, month, day, hour, minute, 0));
+
+  if (configuration.Is_Daily)
+    RTC.setAlarm(ALM1_MATCH_HOURS, configuration.SAMin, configuration.SAHr, 0);
+  else
+    setAlarmPeriod();
+}

--- a/PythonScripts/WaterSamplerDrain.py
+++ b/PythonScripts/WaterSamplerDrain.py
@@ -33,7 +33,7 @@ time.sleep(3)
 
 """
 ## open Valve 1
-ser.write(b'V1 1\r')
+ser.write(b'VS 1 1\r')
 time.sleep(1)
 ## Turn Motor on reverse
 ser.write(b'M -1'\r)
@@ -50,8 +50,8 @@ else:
     motorOn = 'M1 \r\n'
 
 
-FlushOff = 'V0 0\r\n'
-FirstValveOn = 'V1 1\r\n'
+FlushOff = 'VS 0 0\r\n'
+FirstValveOn = 'VS 1 1\r\n'
 motorOff = 'M0 \r\n'
 
 
@@ -86,7 +86,7 @@ time.sleep(pumpTime)
 for i in range(firstBag, numBags+1):
     ##Make new valve string, Vn set based on lumber interation into loop
     ## found on https://stackoverflow.com/questions/5309978/sprintf-like-functionality-in-python
-    buf = 'V%d 1\r\n' % i
+    buf = 'VS %d 1\r\n' % i
     print(buf)
     ser.write(buf.encode('ascii'))
     ## resend motor on signal in case it turnes off accidentally


### PR DESCRIPTION
This PR refactors the serial command set so that the original file handles all of the input parsing & output for the serial commands, and all of the commands' functionality are now in `ConfigurationMethods.ino`. (In the long term it would be nice to turn the configuration struct into a class w/ these methods, but I'm not going to worry about that for now.)

This is so that the separate functions can also be used when we're parsing the Bluetooth communication.

Some of the commenting is a bit inconsistent, but I'm trying to avoid spending too much time on cleanup until we have the basics done.

After this is approved I'm going to rebase all of my commits into one, but for now the history is intact.